### PR TITLE
Move secrets to correct place

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -70,10 +70,10 @@ const createRevision = async (
       command: revisionInputs.command,
       args: revisionInputs.args,
       environment: revisionInputs.environment,
-      secrets: revisionInputs.secrets,
       workingDir: revisionInputs.workingDir,
     },
     concurrency: revisionInputs.concurrency,
+    secrets: revisionInputs.secrets,
   } as any;
 
   if (revisionInputs.provisioned !== undefined) {


### PR DESCRIPTION
`secrets` – не часть `imageSpec`, он задаётся на верхнем уровне (хотя не очень понятно, чем это глобально отличается от `environment`)

https://cloud.yandex.ru/docs/serverless-containers/containers/api-ref/Container/deployRevision