### PR TITLE
Fix invalid split of env line with multiple =

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@jest/globals';
 import {
   Secret,
-  parseLockboxVariablesMapping,
+  parseLockboxVariablesMapping, parseEnvironment,
 } from '../src/main';
 
 // This test will run only in fully configured env and creates real containers
@@ -60,4 +60,19 @@ describe('lockbox', () => {
       expect(() => parseLockboxVariablesMapping(input)).toThrow();
     },
   );
+});
+
+describe('environment', () => {
+  test('it should parse envs with multiple =', () => {
+    const input = [
+      'DATABASE_URL=postgresql://user:password@host:port/db?sslmode=verify-full&target_session_attrs=read-write',
+      'GOOGLE_CLIENT_ID=id.apps.googleusercontent.com',
+    ];
+    const result = parseEnvironment(input);
+    const expected: { [key: string]: string } = {
+      DATABASE_URL: 'postgresql://user:password@host:port/db?sslmode=verify-full&target_session_attrs=read-write',
+      GOOGLE_CLIENT_ID: 'id.apps.googleusercontent.com',
+    };
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,7 +128,8 @@ const parseRevisionInputs = (): IRevisionInputs => {
   const environment: { [key: string]: string } = {};
 
   for (const line of env) {
-    const [key, value] = line.split('=');
+    const i = line.indexOf('=');
+    const [key, value] = [line.slice(0, i), line.slice(i + 1)];
 
     environment[key?.trim()] = value?.trim();
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,16 +123,8 @@ const parseRevisionInputs = (): IRevisionInputs => {
   const argList: string[] = core.getMultilineInput('revision-args');
 
   const args = argList.length > 0 ? { args: argList } : undefined;
-  const env: string[] = core.getMultilineInput('revision-env');
+  const environment: { [key: string]: string } = parseEnvironment(core.getMultilineInput('revision-env'));
   const secrets: Secret[] = parseLockboxVariablesMapping(core.getMultilineInput('revision-secrets'));
-  const environment: { [key: string]: string } = {};
-
-  for (const line of env) {
-    const i = line.indexOf('=');
-    const [key, value] = [line.slice(0, i), line.slice(i + 1)];
-
-    environment[key?.trim()] = value?.trim();
-  }
 
   let provisioned = undefined;
 
@@ -229,6 +221,20 @@ const parseLockboxSecretDefinition = (line: string) => {
     key,
   };
 };
+
+export const parseEnvironment = (envLines: string[]): { [key: string]: string } => {
+  const environment: { [key: string]: string } = {};
+
+  for (const line of envLines) {
+    const i = line.indexOf('=');
+    const [key, value] = [line.slice(0, i), line.slice(i + 1)];
+
+    environment[key?.trim()] = value?.trim();
+  }
+
+  return environment;
+};
+
 
 // environmentVariable=id/versionId/key
 export const parseLockboxVariablesMapping = (secrets: string[]): Secret[] => {


### PR DESCRIPTION
Сейчас action плохо парсит переменные среды вида:

```
DATABASE_URL=postgresql://AkEEr6FgMr:ENXUI7nBdh@rc1b-hVXMNH00SC.mdb.yandexcloud.net:6432/db1?sslmode=verify-full&target_session_attrs=read-write
```

В такой переменной несколько `=`

Текущий код:

```
const [key, value] = line.split('=');
```

Обрежет `DATABASE_URL` до `sslmode` - что некорректно 

Поправил это